### PR TITLE
ci(deploy): Update Node.js version to 22 in GitHub Actions workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
           cache-dependency-path: v3/package-lock.json
 


### PR DESCRIPTION
- Update Node.js runtime version from 20 to 22 in deploy workflow
- Ensures CI/CD pipeline uses latest LTS Node.js version
- Maintains compatibility with current development environment